### PR TITLE
Add support for backup builder profiles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   profile-name:
     description: "The profile name to use for the WarpBuild Docker Builders"
     required: true
+  backup-profile-names:
+    description: "A comma-separated list of backup profile names to try if the main profile fails"
+    required: false
+    default: ""
   should-setup-buildx:
     description: "Whether to run setup-buildx automatically or not, if false only the outputs will be returned"
     required: false

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -25744,6 +25744,8 @@ async function makeWarpBuildRequest(url, options, data = null) {
  * Assigns builders for a given profile
  * @param {WarpBuildConfig} config - WarpBuild configuration
  * @param {string} profileName - Profile name to assign builders for
+ * @param {number} startTime - Starting time in milliseconds
+ * @param {number} timeout - Timeout in milliseconds
  * @returns {Promise<Object>} - Parsed response with builder instances
  */
 async function assignBuilders(config, profileName, startTime, timeout) {
@@ -25751,6 +25753,16 @@ async function assignBuilders(config, profileName, startTime, timeout) {
 
     while (true) {
         try {
+            // Check for timeout before making the request
+            const currentTime = Date.now();
+            const elapsedTime = currentTime - startTime;
+            
+            if (elapsedTime >= timeout) {
+                const timeoutError = new Error(`TIMEOUT: Profile ${profileName} exceeded timeout of ${timeout}ms after ${elapsedTime}ms`);
+                timeoutError.isTimeout = true;
+                throw timeoutError;
+            }
+            
             const response = await makeWarpBuildRequest(
                 config.getAssignBuilderEndpoint(),
                 {
@@ -25774,21 +25786,35 @@ async function assignBuilders(config, profileName, startTime, timeout) {
                 throw new Error(`API Error: ${response.statusCode} - ${JSON.stringify(responseData)}`);
             }
 
-            const currentTime = Date.now();
-            const elapsedTime = currentTime - startTime;
-
-            if (elapsedTime >= timeout) {
-                core.error(`ERROR: Global script timeout of ${timeout}ms exceeded after ${elapsedTime}ms`);
-                core.error('Script execution terminated');
-                throw new Error(`ERROR: Global script timeout of ${timeout}ms exceeded after ${elapsedTime}ms`);
-            }
-
             // Extract error information from response
             const errorDescription = responseData.description || 'No description provided';
             core.info(`Assign builder failed: HTTP Status ${response.statusCode} - ${errorDescription}`);
             core.info('Waiting 10 seconds before next attempt...');
+            
+            // Check if waiting would exceed the timeout
+            if (elapsedTime + 10000 >= timeout) {
+                const timeoutError = new Error(`TIMEOUT: Profile ${profileName} would exceed timeout of ${timeout}ms after waiting`);
+                timeoutError.isTimeout = true;
+                throw timeoutError;
+            }
+            
             await new Promise(resolve => setTimeout(resolve, 10000));
         } catch (error) {
+            // If it's already a timeout error, rethrow it
+            if (error.isTimeout) {
+                throw error;
+            }
+            
+            // Check for timeout after an error
+            const currentTime = Date.now();
+            const elapsedTime = currentTime - startTime;
+            
+            if (elapsedTime >= timeout) {
+                const timeoutError = new Error(`TIMEOUT: Profile ${profileName} exceeded timeout of ${timeout}ms after error: ${error.message}`);
+                timeoutError.isTimeout = true;
+                throw timeoutError;
+            }
+            
             core.warning(`Request failed: ${error.message}`);
             await new Promise(resolve => setTimeout(resolve, 10000));
         }

--- a/dist/main.js
+++ b/dist/main.js
@@ -28630,12 +28630,10 @@ async function run() {
                 // Save state for post cleanup
                 core.saveState('WARPBUILD_BUILDERS', JSON.stringify(buildersState));
 
-                // Setup each builder node with a fresh timeout
+                // Setup each builder node
                 for (let j = 0; j < responseData.builder_instances.length; j++) {
                     const builderId = responseData.builder_instances[j].id;
                     
-                    // Use a fresh start time for setup
-                    const setupStartTime = Date.now();
                     await setupBuildxNode(
                         j,
                         builderId,

--- a/dist/main.js
+++ b/dist/main.js
@@ -28561,38 +28561,87 @@ async function run() {
         const startTime = Date.now();
         const timeout = parseInt(core.getInput('timeout')) || 200000;
         const profileName = core.getInput('profile-name', { required: true });
+        const backupProfileNamesInput = core.getInput('backup-profile-names');
         const shouldSetupBuildx = core.getInput('should-setup-buildx') !== 'false';
 
-        // Initialize WarpBuild configuration
-        const config = new WarpBuildConfig();
+        // Parse backup profiles
+        let backupProfiles = [];
+        if (backupProfileNamesInput) {
+            backupProfiles = backupProfileNamesInput.split(',').map(p => p.trim()).filter(Boolean);
+            core.info(`Found ${backupProfiles.length} backup profiles: ${backupProfiles.join(', ')}`);
+        }
 
-        // Assign builders
-        const responseData = await assignBuilders(config, profileName, startTime, timeout);
-        const builderName = `builder-${uuidv4()}`;
+        // Try each profile in sequence until one works
+        let allProfiles = [profileName, ...backupProfiles];
+        let builderSetupSuccessful = false;
+        let lastError = null;
 
-        // Save builder information for cleanup
-        const buildersState = {
-            builderName,
-            builders: responseData.builder_instances.map(b => ({
-                id: b.id,
-                index: responseData.builder_instances.indexOf(b)
-            }))
-        };
+        for (let i = 0; i < allProfiles.length; i++) {
+            const currentProfile = allProfiles[i];
+            core.info(`Trying profile: ${currentProfile}${i > 0 ? ' (backup)' : ''}`);
+            
+            try {
+                // Start fresh timer for each profile attempt
+                const profileStartTime = Date.now();
+                
+                // Initialize WarpBuild configuration
+                const config = new WarpBuildConfig();
+
+                // Assign builders
+                const responseData = await assignBuilders(config, currentProfile, profileStartTime, timeout);
+                
+                const builderName = `builder-${uuidv4()}`;
+
+                // Save builder information for cleanup
+                const buildersState = {
+                    builderName,
+                    builders: responseData.builder_instances.map(b => ({
+                        id: b.id,
+                        index: responseData.builder_instances.indexOf(b)
+                    }))
+                };
+                
+                // Save state for post cleanup
+                core.saveState('WARPBUILD_BUILDERS', JSON.stringify(buildersState));
+
+                // Setup each builder node with a fresh timeout
+                for (let j = 0; j < responseData.builder_instances.length; j++) {
+                    const builderId = responseData.builder_instances[j].id;
+                    
+                    // Use a fresh start time for setup
+                    const setupStartTime = Date.now();
+                    await setupBuildxNode(
+                        j,
+                        builderId,
+                        builderName,
+                        config,
+                        timeout,
+                        setupStartTime,
+                        shouldSetupBuildx
+                    );
+                }
+                
+                core.info(`Successfully set up Docker builders with profile: ${currentProfile}`);
+                builderSetupSuccessful = true;
+                break;
+                
+            } catch (error) {
+                lastError = error;
+                core.warning(`Failed to set up with profile ${currentProfile}: ${error.message}`);
+                
+                // Check if we're on the last profile
+                if (i === allProfiles.length - 1) {
+                    core.error(`All profiles failed, including backup profiles`);
+                    throw error;
+                }
+                
+                // Log that we're trying the next backup profile
+                core.info(`Trying next backup profile...`);
+            }
+        }
         
-        // Save state for post cleanup
-        core.saveState('WARPBUILD_BUILDERS', JSON.stringify(buildersState));
-
-        // Setup each builder node
-        for (let i = 0; i < responseData.builder_instances.length; i++) {
-            await setupBuildxNode(
-                i,
-                responseData.builder_instances[i].id,
-                builderName,
-                config,
-                timeout,
-                startTime,
-                shouldSetupBuildx
-            );
+        if (!builderSetupSuccessful) {
+            throw lastError || new Error("Failed to set up Docker builders with any profile");
         }
 
     } catch (error) {

--- a/main.js
+++ b/main.js
@@ -169,7 +169,17 @@ async function run() {
                 
             } catch (error) {
                 lastError = error;
-                core.warning(`Failed to set up with profile ${currentProfile}: ${error.message}`);
+                
+                // Check if this is a timeout error
+                const isTimeoutError = error.isTimeout || 
+                                     (error.message && (error.message.includes('TIMEOUT:') || 
+                                                      error.message.includes('Global script timeout')));
+                
+                if (isTimeoutError) {
+                    core.warning(`Profile ${currentProfile} timed out: ${error.message}`);
+                } else {
+                    core.warning(`Failed to set up with profile ${currentProfile}: ${error.message}`);
+                }
                 
                 // Check if we're on the last profile
                 if (i === allProfiles.length - 1) {

--- a/main.js
+++ b/main.js
@@ -146,12 +146,10 @@ async function run() {
                 // Save state for post cleanup
                 core.saveState('WARPBUILD_BUILDERS', JSON.stringify(buildersState));
 
-                // Setup each builder node with a fresh timeout
+                // Setup each builder node
                 for (let j = 0; j < responseData.builder_instances.length; j++) {
                     const builderId = responseData.builder_instances[j].id;
                     
-                    // Use a fresh start time for setup
-                    const setupStartTime = Date.now();
                     await setupBuildxNode(
                         j,
                         builderId,

--- a/utils/warpbuild.js
+++ b/utils/warpbuild.js
@@ -96,6 +96,8 @@ async function makeWarpBuildRequest(url, options, data = null) {
  * Assigns builders for a given profile
  * @param {WarpBuildConfig} config - WarpBuild configuration
  * @param {string} profileName - Profile name to assign builders for
+ * @param {number} startTime - Starting time in milliseconds
+ * @param {number} timeout - Timeout in milliseconds
  * @returns {Promise<Object>} - Parsed response with builder instances
  */
 async function assignBuilders(config, profileName, startTime, timeout) {
@@ -103,6 +105,16 @@ async function assignBuilders(config, profileName, startTime, timeout) {
 
     while (true) {
         try {
+            // Check for timeout before making the request
+            const currentTime = Date.now();
+            const elapsedTime = currentTime - startTime;
+            
+            if (elapsedTime >= timeout) {
+                const timeoutError = new Error(`TIMEOUT: Profile ${profileName} exceeded timeout of ${timeout}ms after ${elapsedTime}ms`);
+                timeoutError.isTimeout = true;
+                throw timeoutError;
+            }
+            
             const response = await makeWarpBuildRequest(
                 config.getAssignBuilderEndpoint(),
                 {
@@ -126,21 +138,35 @@ async function assignBuilders(config, profileName, startTime, timeout) {
                 throw new Error(`API Error: ${response.statusCode} - ${JSON.stringify(responseData)}`);
             }
 
-            const currentTime = Date.now();
-            const elapsedTime = currentTime - startTime;
-
-            if (elapsedTime >= timeout) {
-                core.error(`ERROR: Global script timeout of ${timeout}ms exceeded after ${elapsedTime}ms`);
-                core.error('Script execution terminated');
-                throw new Error(`ERROR: Global script timeout of ${timeout}ms exceeded after ${elapsedTime}ms`);
-            }
-
             // Extract error information from response
             const errorDescription = responseData.description || 'No description provided';
             core.info(`Assign builder failed: HTTP Status ${response.statusCode} - ${errorDescription}`);
             core.info('Waiting 10 seconds before next attempt...');
+            
+            // Check if waiting would exceed the timeout
+            if (elapsedTime + 10000 >= timeout) {
+                const timeoutError = new Error(`TIMEOUT: Profile ${profileName} would exceed timeout of ${timeout}ms after waiting`);
+                timeoutError.isTimeout = true;
+                throw timeoutError;
+            }
+            
             await new Promise(resolve => setTimeout(resolve, 10000));
         } catch (error) {
+            // If it's already a timeout error, rethrow it
+            if (error.isTimeout) {
+                throw error;
+            }
+            
+            // Check for timeout after an error
+            const currentTime = Date.now();
+            const elapsedTime = currentTime - startTime;
+            
+            if (elapsedTime >= timeout) {
+                const timeoutError = new Error(`TIMEOUT: Profile ${profileName} exceeded timeout of ${timeout}ms after error: ${error.message}`);
+                timeoutError.isTimeout = true;
+                throw timeoutError;
+            }
+            
             core.warning(`Request failed: ${error.message}`);
             await new Promise(resolve => setTimeout(resolve, 10000));
         }


### PR DESCRIPTION
This PR adds the ability to specify backup builder profiles that are automatically tried when the main profile fails to assign builders. This is particularly useful for handling high concurrency scenarios.

## Problem

When multiple PRs trigger builds simultaneously, they can hit the concurrency limit of the main builder profile (e.g., 5 concurrent builds). Without fallback logic, these builds would fail after timeout.

## Solution

Added a new backup-profile-names input parameter that accepts a comma-separated list of backup profile names
Implemented profile fallback logic in the main action code that:
* Tries each profile in sequence until one succeeds
* Uses fresh timeouts for each profile attempt
* Provides clear logging during profile switching
* Only fails after all profiles have been exhausted

This approach eliminates the need for action users to implement their own fallback logic at the workflow level, making it easier to handle concurrent build scenarios while still prioritizing cached builders when available.

## Example

```yaml
- uses: warpbuild/docker-configure@main
   with:
     profile-name: warp-docker-builder   # Main profile with caching
     backup-profile-names: ephemeral-builder  # Fallback profile for high concurrency
     timeout: 60000
```
