### PR TITLE
chore: upgrade Node.js runtime from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,6 @@ outputs:
     description: "The client key for the second Docker builder."
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/main.js'
   post: 'dist/cleanup.js'


### PR DESCRIPTION
## Summary
- Upgrades GitHub Actions Node.js runtime from `node20` to `node24`
- Node.js 20 is being deprecated by GitHub Actions (June 2026 warning, Fall 2026 hard block)
- Rebuilt dist/ after change

## Test plan
- [ ] Verify action works in a test workflow with Node 24 runtime

Made with [Cursor](https://cursor.com)